### PR TITLE
Clarify memory measurements

### DIFF
--- a/README
+++ b/README
@@ -25,8 +25,9 @@ Example
   real: 0m3.953s
   qpc: 3940596us
 
-Meaning it took just under 4 seconds to run some.exe. tim has no command line
-arguments, everything after its name is the subcommand.
+Meaning it took just under 4 seconds to run some.exe and one of the child
+processes in the process tree used a peak of 8.22 MB of commit. tim has no
+command line arguments, everything after its name is the subcommand.
 
 An identical copy of tim.exe is made as timavg.exe. If 'timavg' is used in place
 of 'tim', the subcommand is run 7 times and the average is reported, discarding

--- a/tim.cc
+++ b/tim.cc
@@ -91,6 +91,9 @@ Result Run(LPWSTR command) {
   ULONGLONG end_time = GetTickCount64();
   result.elapsed = end_time - start_time;
 
+  // PeakProcessMemoryUsed is the peak commit used by any of the processes in
+  // the job. Because it is a measure of commit rather than physical RAM it can
+  // be larger than the system's total memory.
   wprintf(L"\npeak memory: %.2fMB", limit.PeakProcessMemoryUsed / 1e6);
   wprintf(L"\nreal: %lldm%.03fs\nqpc: %lldus\n",
           result.elapsed / (60 * 1000),


### PR DESCRIPTION
The precise meaning of the tim.exe memory measurement is not obvious and
this ambiguity makes it less useful. While doing ninja measurements I
couldn't tell if it referred to physical memory or commit (it's commit)
and I couldn't tell if it referred to the peak of a single process or of
the process tree (single process).

This updates the README and adds code comments to clarify this.